### PR TITLE
Manage collisions

### DIFF
--- a/Unity-City-Planning/Assets/DataModel/UnityDataWatcher.cs
+++ b/Unity-City-Planning/Assets/DataModel/UnityDataWatcher.cs
@@ -43,6 +43,9 @@ public class UnityDataWatcher : MonoBehaviour, IDataWatcher
                 // another building with the same coordinates exists
                 // or the building overlaps with a road
                 if (drawnBuildings.Contains(b.Location) || collisionDetected(b,municipality.roads)){
+                    if(drawnBuildings.Contains(b.Location)){
+                        Debug.Log("ERROR: Building already exists");
+                    }
                     //do nothing and go to next building
                     continue;
                 }
@@ -183,6 +186,7 @@ public class UnityDataWatcher : MonoBehaviour, IDataWatcher
                     break;
             }
             if (collision){
+                Debug.Log("ERROR: Buildings and roads are overlapping");
                 return true;
             }
         }


### PR DESCRIPTION
I added collision detection for buildings.
- To avoid drawing multiple buildings at the same spot.

- To avoid drawing a building in the middle of a road.

However, I didn't check for overlaps between roads (which shouldn't be a problem since the city should be able to have road intersections). I also assumed that each building has the size 1. But as discussed in the group meeting today, we will likely keep it that way.